### PR TITLE
docs: describe Amplify auth demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # nimbuschat
-Real time chat app
+
+This repository currently provides a simple demo for user signup and login
+using AWS Amplify. Real-time chat functionality has not been implemented yet.
+
+## Demo
+
+1. Open `index.html` in your web browser. You can double-click the file or
+   drag it into a browser window.
+2. Use the **Signup** form to create a new account.
+3. Confirm the signup via email if required, then return to `index.html` and
+   use the **Login** form to sign in.
+
+That's all there is for now—chat features are coming in the future.


### PR DESCRIPTION
## Summary
- clarify repository description and note lack of chat feature
- add instructions for opening `index.html` to try AWS Amplify signup/login demo

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e4b1fa60c832cbde3774de578a60a